### PR TITLE
Fix URL of CallbackHelper dependency in library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     },
     "dependencies":
     {
-    "CallbackHelper": "https://github.com/luni64/CalbackHelper.git#>0.1.2"
+    "CallbackHelper": "https://github.com/luni64/CallbackHelper.git#v0.1.2"
     },
     "homepage": "https://github.com/luni64/IntervalTimerEx",
     "version": "0.1.0",


### PR DESCRIPTION
There was a little type in the URL as well as in the version string.